### PR TITLE
Add simple Android reminder app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
-# reminder
-simple reminder app
+# Reminder
+
+This is a simple Android reminder app. It allows you to schedule daily notifications at a specific time. Each notification includes actions to snooze for 5 minutes, 30 minutes, or in one hour increments.
+
+## Features
+- Set a daily reminder using the time picker
+- Notifications with snooze options (5 min, 30 min, +1 hr)
+
+## Building
+You need Android Studio Flamingo or later. Open this project in Android Studio and run the `app` configuration on a device or emulator.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,0 +1,36 @@
+plugins {
+    id 'com.android.application'
+    id 'kotlin-android'
+}
+
+android {
+    compileSdkVersion 33
+    defaultConfig {
+        applicationId "com.example.reminder"
+        minSdkVersion 21
+        targetSdkVersion 33
+        versionCode 1
+        versionName "1.0"
+    }
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+}
+
+dependencies {
+    implementation 'androidx.core:core-ktx:1.10.1'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.android.material:material:1.9.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+}
+

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+# Proguard rules

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,0 +1,23 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.reminder">
+
+    <application
+        android:allowBackup="true"
+        android:label="Reminder"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.Material3.DayNight.NoActionBar">
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
+        <receiver
+            android:name=".ReminderReceiver"
+            android:exported="false" />
+        <receiver
+            android:name=".SnoozeReceiver"
+            android:exported="false" />
+    </application>
+</manifest>

--- a/app/src/main/java/com/example/reminder/MainActivity.kt
+++ b/app/src/main/java/com/example/reminder/MainActivity.kt
@@ -1,0 +1,33 @@
+package com.example.reminder
+
+import android.os.Bundle
+import android.widget.Button
+import android.widget.TimePicker
+import androidx.appcompat.app.AppCompatActivity
+
+class MainActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+
+        val timePicker: TimePicker = findViewById(R.id.timePicker)
+        val setButton: Button = findViewById(R.id.setReminderButton)
+
+        setButton.setOnClickListener {
+            val hour = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
+                timePicker.hour
+            } else {
+                @Suppress("DEPRECATION")
+                timePicker.currentHour
+            }
+            val minute = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
+                timePicker.minute
+            } else {
+                @Suppress("DEPRECATION")
+                timePicker.currentMinute
+            }
+            val scheduler = ReminderScheduler(this)
+            scheduler.scheduleDaily(hour, minute)
+        }
+    }
+}

--- a/app/src/main/java/com/example/reminder/ReminderReceiver.kt
+++ b/app/src/main/java/com/example/reminder/ReminderReceiver.kt
@@ -1,0 +1,75 @@
+package com.example.reminder
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+
+class ReminderReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        createChannel(context)
+
+        val snoozeIntent5 = Intent(context, SnoozeReceiver::class.java).apply {
+            putExtra("delay", 5 * 60 * 1000L)
+        }
+        val snooze5 = PendingIntent.getBroadcast(
+            context,
+            1,
+            snoozeIntent5,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val snoozeIntent30 = Intent(context, SnoozeReceiver::class.java).apply {
+            putExtra("delay", 30 * 60 * 1000L)
+        }
+        val snooze30 = PendingIntent.getBroadcast(
+            context,
+            2,
+            snoozeIntent30,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val incrementIntent = Intent(context, SnoozeReceiver::class.java).apply {
+            putExtra("delay", 60 * 60 * 1000L)
+            putExtra("increment", true)
+        }
+        val increment = PendingIntent.getBroadcast(
+            context,
+            3,
+            incrementIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(android.R.drawable.ic_popup_reminder)
+            .setContentTitle("Reminder")
+            .setContentText("It's time for your task")
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setAutoCancel(true)
+            .addAction(0, "Snooze 5m", snooze5)
+            .addAction(0, "Snooze 30m", snooze30)
+            .addAction(0, "+1 hr", increment)
+            .build()
+
+        with(NotificationManagerCompat.from(context)) {
+            notify(1001, notification)
+        }
+    }
+
+    private fun createChannel(context: Context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(CHANNEL_ID, "Reminders", NotificationManager.IMPORTANCE_HIGH)
+            val manager = context.getSystemService(NotificationManager::class.java)
+            manager.createNotificationChannel(channel)
+        }
+    }
+
+    companion object {
+        const val CHANNEL_ID = "reminder_channel"
+    }
+}

--- a/app/src/main/java/com/example/reminder/ReminderScheduler.kt
+++ b/app/src/main/java/com/example/reminder/ReminderScheduler.kt
@@ -1,0 +1,45 @@
+package com.example.reminder
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import java.util.Calendar
+
+class ReminderScheduler(private val context: Context) {
+    private val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+
+    fun scheduleDaily(hour: Int, minute: Int) {
+        val triggerTime = Calendar.getInstance().apply {
+            timeInMillis = System.currentTimeMillis()
+            set(Calendar.HOUR_OF_DAY, hour)
+            set(Calendar.MINUTE, minute)
+            set(Calendar.SECOND, 0)
+            if (before(Calendar.getInstance())) {
+                add(Calendar.DAY_OF_YEAR, 1)
+            }
+        }.timeInMillis
+
+        val intent = Intent(context, ReminderReceiver::class.java)
+        val pending = PendingIntent.getBroadcast(
+            context,
+            0,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerTime, pending)
+    }
+
+    fun scheduleInMillis(delayMillis: Long) {
+        val triggerTime = System.currentTimeMillis() + delayMillis
+        val intent = Intent(context, ReminderReceiver::class.java)
+        val pending = PendingIntent.getBroadcast(
+            context,
+            0,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+        alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerTime, pending)
+    }
+}

--- a/app/src/main/java/com/example/reminder/SnoozeReceiver.kt
+++ b/app/src/main/java/com/example/reminder/SnoozeReceiver.kt
@@ -1,0 +1,19 @@
+package com.example.reminder
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+
+class SnoozeReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        val delay = intent.getLongExtra("delay", 0L)
+        val increment = intent.getBooleanExtra("increment", false)
+
+        val scheduler = ReminderScheduler(context)
+        if (increment) {
+            scheduler.scheduleInMillis(delay)
+        } else {
+            scheduler.scheduleInMillis(delay)
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <TimePicker
+        android:id="@+id/timePicker"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:timePickerMode="spinner" />
+
+    <Button
+        android:id="@+id/setReminderButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Set Daily Reminder" />
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">Reminder</string>
+</resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,0 +1,5 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.Material3.DayNight.NoActionBar" parent="Theme.Material3.DayNight.NoActionBar">
+        <item name="android:statusBarColor">?attr/colorPrimary</item>
+    </style>
+</resources>

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,16 @@
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath "com.android.tools.build:gradle:8.1.0"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.10"
+    }
+}
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.jvmargs=-Xmx2048m
+android.useAndroidX=true
+kotlin.code.style=official

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,2 @@
+rootProject.name = "Reminder"
+include(":app")


### PR DESCRIPTION
## Summary
- build simple Android project for reminders
- implement `ReminderScheduler` with AlarmManager
- show notification with snooze actions via `ReminderReceiver`
- allow picking reminder time from `MainActivity`
- document build instructions in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68446c7acf188333bf5948ee216f7ab7